### PR TITLE
Not enough space for 'Choose The Color' button

### DIFF
--- a/assets/js/components/product/actions.vue
+++ b/assets/js/components/product/actions.vue
@@ -3,7 +3,7 @@
 .actions
   .row
 
-    grid( xs="8" )
+    grid( xs="7" )
 
       button.btn.love(
         class="{{ product.liked ? 'loved' : '' }}"
@@ -24,7 +24,7 @@
             span Facebook
 
     grid(
-      xs="4"
+      xs="5"
       classes="text-right" )
       button.psr.btn.buy( @click="addToCart" ) {{ addToCartClicked ? 'Choose The Color' : 'Add To Cart' }}
 </template>


### PR DESCRIPTION
When using small screen, page layout is broken after click Add To Cart because there is not enough space for 'Choose The Color' button.
